### PR TITLE
[DEV-15] Fix GridSearchCV ranking issue with ties in highest test_mean_score

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -737,7 +737,6 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 if rank == 1:
                     firsts.append((i,abs(results["mean_train_score"][i] - results["mean_test_score"][i])))
             best_index = min(firsts, key=lambda item: item[1])[0]
-            print(best_index)
         return best_index
 
     def fit(self, X, y=None, *, groups=None, **fit_params):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -732,7 +732,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             if best_index < 0 or best_index >= len(results["params"]):
                 raise IndexError("best_index_ index out of range")
         else:
-            best_index = results[f"rank_test_{refit_metric}"].argmin()
+            firsts = []
+            for i, rank in enumerate(results[f"rank_test_{refit_metric}"]):
+                if rank == 1:
+                    firsts.append((i,abs(results["mean_train_score"][i] - results["mean_test_score"][i])))
+            best_index = min(firsts, key=lambda item: item[1])[0]
+            print(best_index)
         return best_index
 
     def fit(self, X, y=None, *, groups=None, **fit_params):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -732,11 +732,14 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             if best_index < 0 or best_index >= len(results["params"]):
                 raise IndexError("best_index_ index out of range")
         else:
-            firsts = []
-            for i, rank in enumerate(results[f"rank_test_{refit_metric}"]):
-                if rank == 1:
-                    firsts.append((i,abs(results["mean_train_score"][i] - results["mean_test_score"][i])))
-            best_index = min(firsts, key=lambda item: item[1])[0]
+            if "mean_train_score" in results and "mean_test_score" in results:
+                firsts = []
+                for i, rank in enumerate(results[f"rank_test_{refit_metric}"]):
+                    if rank == 1:
+                        firsts.append((i,abs(results["mean_train_score"][i] - results["mean_test_score"][i])))
+                best_index = min(firsts, key=lambda item: item[1])[0]
+            else:
+                best_index = results[f"rank_test_{refit_metric}"].argmin()
         return best_index
 
     def fit(self, X, y=None, *, groups=None, **fit_params):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2411,7 +2411,7 @@ def test_search_cv_verbose_3(capsys, return_train_score):
         match = re.findall(r"score=[\d\.]+", captured)
     assert len(match) == 3
 
-# pytest -v .\sklearn\model_selection\tests\test_search.py
+
 @pytest.mark.parametrize(
     "params, best_params",
     [


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
https://github.com/scikit-learn/scikit-learn/issues/21895

#### What does this implement/fix? Explain your changes.
This fixes an bug with GridSearchCV where the ranking of test scores could be incorrect if there was a tie in the highest `mean_test_score`. 
Previously, the best_params would be arbitrarily be determined based on the order of the input params if there was a tie.
Now, the best params will be the one with a smaller difference between the `mean_test_score` and `mean_train_score` among those with the highest `mean_test_score.

Unit tests to validate this bugfix have been added to `test_search.py`, you can run the tests with the following command:
`pytest -v .\sklearn\model_selection\tests\test_search.py`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
